### PR TITLE
Add a `comment-word-disallowed-list` rule to mimic our ESLint config

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ export default {
     "color-named": "always-where-possible",
     "color-no-invalid-hex": true,
     "comment-no-empty": null,
+    "comment-word-disallowed-list": ["/\\b(?:fixme|todo)\\b/i"],
     "custom-property-pattern": null,
     "declaration-block-no-duplicate-properties": [
       true,


### PR DESCRIPTION
Resolvees #11